### PR TITLE
angler: update dexpreopt option

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -104,6 +104,7 @@ BOARD_CHARGER_ENABLE_SUSPEND := true
 ifeq ($(HOST_OS),linux)
   ifneq ($(TARGET_BUILD_VARIANT),eng)
     ifeq ($(WITH_DEXPREOPT),)
+      WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY := false
       WITH_DEXPREOPT := true
     endif
   endif


### PR DESCRIPTION
The recent change we made in the build repo makes all
builds dexpreopt only boot img and system server.
This changes angler builds back to full dexpreopt.

Change-Id: I0cf03634ee7bbc93b18b49d3f1efe82a6302b447