### PR TITLE
angler: Enable boot and system server dex-preopt

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -160,6 +160,16 @@ BOARD_PERFSETUP_SCRIPT := platform_testing/scripts/perf-setup/angler-setup.sh
 
 TARGET_FS_CONFIG_GEN += device/huawei/angler/config.fs
 
+# Dexpreopt
+ifeq ($(HOST_OS),linux)
+  ifneq ($(TARGET_BUILD_VARIANT),eng)
+    ifeq ($(WITH_DEXPREOPT),)
+      WITH_DEXPREOPT := true
+      WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY := true
+    endif
+  endif
+endif
+
 DEVICE_MANIFEST_FILE := device/huawei/angler/manifest.xml
 DEVICE_MATRIX_FILE := device/huawei/angler/compatibility_matrix.xml
 


### PR DESCRIPTION
As stated in https://android.googlesource.com/platform/build/+/418258c
this is required in O-MR1 since sepolicy now prevents system server from
loading anything from /data making our system extremely slow and janky.

Change-Id: I215ec7ebe95981ef0b953fe938e12b83675795ab